### PR TITLE
TLS state is now printed to the output for ECH-enabled connections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Fixed
+
+* TLS state is now printed to the output for ECH-enabled connections. In
+  addition to that, much more TLS-related information is printed to the output
+  including information about TLS certificates. ([#8][#8])
+
+[#8]: https://github.com/ameshkov/gocurl/issues/8
+
 [unreleased]: https://github.com/ameshkov/gocurl/compare/v1.1.0...HEAD
 
 ## [1.1.0] - 2023-09-21

--- a/internal/client/ech/ech.go
+++ b/internal/client/ech/ech.go
@@ -4,6 +4,7 @@ package ech
 import (
 	"crypto/tls"
 	"net"
+	"time"
 
 	ctls "github.com/ameshkov/cfcrypto/tls"
 	"github.com/ameshkov/gocurl/internal/output"
@@ -46,5 +47,89 @@ func HandshakeECH(
 
 	out.Debug("ECH-enabled connection has been established successfully")
 
-	return c, nil
+	return &connWrapper{
+		baseConn: c,
+	}, nil
+}
+
+// tlsConnectionStater is an interface that declares ConnectionState function
+// of tls.Conn.  The reason for implementing this is to allow HTTP client to
+// get access to the TLS connection state and expose it via http.Response.TLS
+type tlsConnectionStater interface {
+	ConnectionState() (state tls.ConnectionState)
+}
+
+// connWrapper is a wrapper over *ctls.Conn that implements tlsConnectionStater
+// interface and provides a way for HTTP client to get access to TLS properties
+// of the connection.
+type connWrapper struct {
+	*tls.Conn
+
+	// baseConn
+	baseConn *ctls.Conn
+}
+
+// type check
+var _ net.Conn = (*connWrapper)(nil)
+
+// type check
+var _ tlsConnectionStater = (*connWrapper)(nil)
+
+// ConnectionState implements the tlsConnectionStater for *connWrapper.
+func (c *connWrapper) ConnectionState() (state tls.ConnectionState) {
+	innerState := c.baseConn.ConnectionState()
+
+	state.Version = innerState.Version
+	state.NegotiatedProtocol = innerState.NegotiatedProtocol
+	state.ServerName = innerState.ServerName
+	state.CipherSuite = innerState.CipherSuite
+	state.DidResume = innerState.DidResume
+	state.HandshakeComplete = innerState.HandshakeComplete
+	state.OCSPResponse = innerState.OCSPResponse
+	state.PeerCertificates = innerState.PeerCertificates
+	state.SignedCertificateTimestamps = innerState.SignedCertificateTimestamps
+	state.TLSUnique = innerState.TLSUnique
+	state.VerifiedChains = innerState.VerifiedChains
+
+	return state
+}
+
+// Read implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) Read(b []byte) (n int, err error) {
+	return c.baseConn.Read(b)
+}
+
+// Write implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) Write(b []byte) (n int, err error) {
+	return c.baseConn.Write(b)
+}
+
+// Close implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) Close() (err error) {
+	return c.baseConn.Close()
+}
+
+// LocalAddr implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) LocalAddr() (addr net.Addr) {
+	return c.baseConn.LocalAddr()
+}
+
+// RemoteAddr implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) RemoteAddr() (addr net.Addr) {
+	return c.baseConn.RemoteAddr()
+}
+
+// SetDeadline implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) SetDeadline(t time.Time) (err error) {
+	return c.baseConn.SetDeadline(t)
+}
+
+// SetReadDeadline implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) SetReadDeadline(t time.Time) (err error) {
+	return c.baseConn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline implements the net.Conn interface for *connWrapper.
+func (c *connWrapper) SetWriteDeadline(t time.Time) (err error) {
+	return c.baseConn.SetWriteDeadline(t)
 }

--- a/internal/client/ech/ech.go
+++ b/internal/client/ech/ech.go
@@ -63,9 +63,6 @@ type tlsConnectionStater interface {
 // interface and provides a way for HTTP client to get access to TLS properties
 // of the connection.
 type connWrapper struct {
-	*tls.Conn
-
-	// baseConn
 	baseConn *ctls.Conn
 }
 

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -30,7 +30,7 @@ func (t *transport) RoundTrip(r *http.Request) (resp *http.Response, err error) 
 
 	// Make sure that resp.TLS field is set regardless of what protocol was
 	// used.  This is important for ECH-enabled connections as crypto/tls is
-	// not used there.
+	// not used there and the regular http.Transport will not set the TLS field.
 	type tlsConnectionStater interface {
 		ConnectionState() tls.ConnectionState
 	}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -44,9 +43,9 @@ func Main() {
 
 	out.Debug("Starting gocurl %s with arguments:\n%s", version.Version(), cfg.RawOptions)
 
-	c, err := client.NewClient(cfg, out)
+	transport, err := client.NewTransport(cfg, out)
 	if err != nil {
-		out.Info("Failed to create client: %v", err)
+		out.Info("Failed to create HTTP transport: %v", err)
 
 		os.Exit(1)
 	}
@@ -66,20 +65,11 @@ func Main() {
 	cloneReq, _ := client.NewRequest(cfg)
 	out.DebugRequest(cloneReq)
 
-	resp, err := c.Do(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		out.Info("Failed to make request: %v", err)
 
 		os.Exit(1)
-	}
-
-	if resp.TLS != nil {
-		out.Debug("TLS version: %s", tls.VersionName(resp.TLS.Version))
-		out.Debug("TLS cipher suite: %s", tls.CipherSuiteName(resp.TLS.CipherSuite))
-
-		if resp.TLS.NegotiatedProtocol != "" {
-			out.Debug("TLS negotiated protocol: %s", resp.TLS.NegotiatedProtocol)
-		}
 	}
 
 	out.DebugResponse(resp)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,12 +4,16 @@ package output
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/ameshkov/gocurl/internal/config"
 )
@@ -97,7 +101,36 @@ func (o *Output) DebugRequest(req *http.Request) {
 //
 // TODO(ameshkov): instead of this, log the actual data received from tls.Conn.
 func (o *Output) DebugResponse(resp *http.Response) {
-	o.Debug("Response:\n%s", responseToString(resp))
+	if resp.TLS != nil {
+		s := stateToTLSState(resp.TLS)
+		o.Debug("\n----\nTLS:")
+
+		o.Debug("Server name: %s", s.ServerName)
+		o.Debug("Version: %s", s.Version)
+		o.Debug("Cipher: %s", s.CipherSuite)
+		if s.NegotiatedProtocol != "" {
+			o.Debug("Negotiated protocol: %s", s.NegotiatedProtocol)
+		}
+
+		o.Debug("\n----\nCertificates:")
+		for i, certInfo := range s.Certificates {
+			o.Debug("Certificate №%d:\n", i+1)
+			o.Debug("Subject: %s", certInfo.Subject)
+			o.Debug("Issuer: %s", certInfo.Issuer)
+			o.Debug("Not before: %s", certInfo.NotBefore)
+			o.Debug("Not after: %s", certInfo.NotAfter)
+			if len(certInfo.DNSNames) > 0 {
+				o.Debug("DNS names:\n%s", strings.Join(certInfo.DNSNames, "\n"))
+			}
+			if len(certInfo.IPAddresses) > 0 {
+				o.Debug("IP addresses:\n%s", strings.Join(certInfo.IPAddresses, "\n"))
+			}
+			o.Debug("Raw certificate:")
+			o.Debug(certInfo.Raw)
+		}
+	}
+
+	o.Debug("Response:\n----\n%s", responseToString(resp))
 }
 
 // requestToString converts HTTP request to a string.
@@ -131,10 +164,25 @@ func headersToString(headers http.Header) (str string) {
 	return str
 }
 
+// TLSCertificate is a helper object for serializing information about x509
+// certificates.
+type TLSCertificate struct {
+	Subject     string    `json:"subject"`
+	Issuer      string    `json:"issuer"`
+	NotBefore   time.Time `json:"not_before"`
+	NotAfter    time.Time `json:"not_after"`
+	DNSNames    []string  `json:"dns_names"`
+	IPAddresses []string  `json:"ip_addresses"`
+	Raw         string    `json:"raw"`
+}
+
 // TLSState is a helper object for serializing response data to JSON.
 type TLSState struct {
-	Version     uint16 `json:"version"`
-	CipherSuite uint16 `json:"cipher_suite"`
+	ServerName         string           `json:"server_name"`
+	Version            string           `json:"version"`
+	CipherSuite        string           `json:"cipher_suite"`
+	NegotiatedProtocol string           `json:"negotiated_protocol"`
+	Certificates       []TLSCertificate `json:"certificates"`
 }
 
 // ResponseData is a helper object for serializing response data to JSON.
@@ -144,7 +192,33 @@ type ResponseData struct {
 	Proto      string              `json:"proto"`
 	TLS        *TLSState           `json:"tls"`
 	Headers    map[string][]string `json:"headers"`
-	Body       string              `json:"body"`
+	BodyBase64 string              `json:"body_base64"`
+}
+
+// stateToTLSState converts tls.ConnectionState to TLSState.
+func stateToTLSState(state *tls.ConnectionState) (s *TLSState) {
+	s = &TLSState{
+		ServerName:         state.ServerName,
+		Version:            tls.VersionName(state.Version),
+		CipherSuite:        tls.CipherSuiteName(state.CipherSuite),
+		NegotiatedProtocol: state.NegotiatedProtocol,
+	}
+
+	for _, cert := range state.PeerCertificates {
+		var certInfo TLSCertificate
+		certInfo.Subject = cert.Subject.String()
+		certInfo.Issuer = cert.Issuer.String()
+		certInfo.NotBefore = cert.NotBefore
+		certInfo.NotAfter = cert.NotAfter
+		certInfo.DNSNames = cert.DNSNames
+		for _, ip := range cert.IPAddresses {
+			certInfo.IPAddresses = append(certInfo.IPAddresses, ip.String())
+		}
+		certInfo.Raw = certToPEM(cert.Raw)
+		s.Certificates = append(s.Certificates, certInfo)
+	}
+
+	return s
 }
 
 // responseToJSON transforms response data to JSON format.
@@ -159,18 +233,26 @@ func responseToJSON(resp *http.Response) (b []byte, err error) {
 		Status:     resp.Status,
 		Proto:      resp.Proto,
 		Headers:    resp.Header,
-		Body:       base64.StdEncoding.EncodeToString(body),
+		BodyBase64: base64.StdEncoding.EncodeToString(body),
 	}
 
-	// TODO(ameshkov): fix TLS logging for ECH-enabled requests.
 	if resp.TLS != nil {
-		data.TLS = &TLSState{
-			Version:     resp.TLS.Version,
-			CipherSuite: resp.TLS.CipherSuite,
-		}
+		data.TLS = stateToTLSState(resp.TLS)
 	}
 
 	b, err = json.MarshalIndent(data, "", "  ")
 
 	return b, err
+}
+
+// certToPEM serializes certificate bytes to PEM format.
+func certToPEM(certBytes []byte) (str string) {
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}
+
+	pemBytes := pem.EncodeToMemory(block)
+
+	return string(pemBytes)
 }


### PR DESCRIPTION
In addition to that, much more TLS-related information is printed to the output including information about TLS certificates.

Closes #8