### PR TITLE
Fix go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ameshkov/gocurl
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/AdguardTeam/dnsproxy v0.55.0


### PR DESCRIPTION
```
invalid go version '1.21.1': must match format 1.23
```