### PR TITLE
Fix file creation in output package

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -38,7 +38,7 @@ func NewOutput(path string, verbose bool) (o *Output, err error) {
 	}
 
 	if path != "" {
-		o.receivedDataFile, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0o644)
+		o.receivedDataFile, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	}
 
 	return o, err

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,40 @@
+package output
+
+import (
+	"os"
+	"testing"
+)
+
+// TestNewOutput_truncatesFile ensures that creating a new Output with an existing file truncates it.
+func TestNewOutput_truncatesFile(t *testing.T) {
+	path := "test_output.txt"
+	// Create file with some data
+	err := os.WriteFile(path, []byte("old-data"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to prepare test file: %v", err)
+	}
+
+	o, err := NewOutput(path, false)
+	if err != nil {
+		t.Fatalf("failed to create output: %v", err)
+	}
+	defer func() {
+		_ = o.receivedDataFile.Close()
+		_ = os.Remove(path)
+	}()
+
+	// Write new content
+	_, err = o.receivedDataFile.WriteString("new")
+	if err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	_ = o.receivedDataFile.Close()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+	if string(b) != "new" {
+		t.Fatalf("file not truncated, got: %q", string(b))
+	}
+}


### PR DESCRIPTION
## Summary
- ensure the output file is truncated when created
- add a regression test for NewOutput

## Testing
- `go test ./internal/output -run TestNewOutput -v` *(fails: no network)*
- `go test ./...` *(fails: no network)*