### PR TITLE
Add --cacert option to provide custom CA certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ Application Options:
       --connect-timeout=<seconds>                           Maximum time in seconds allowed for the connection phase.
   -I, --head                                                Fetch the headers only.
   -k, --insecure                                            Disables TLS verification of the connection.
+      --cacert=<file>                                       Path to custom CA
+                                                            certificate file.
       --tlsv1.3                                             Forces gocurl to use TLS v1.3 or newer.
       --tlsv1.2                                             Forces gocurl to use TLS v1.2 or newer.
       --tls-max=<VERSION>                                   (TLS) VERSION defines maximum supported TLS version. Can be

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -43,6 +44,9 @@ type Config struct {
 
 	// Insecure disables TLS verification of the connection.
 	Insecure bool
+
+	// Provide your own CA certificates
+	CACert string
 
 	// TLSMinVersion is a minimum supported TLS version.
 	TLSMinVersion uint16
@@ -181,6 +185,7 @@ func ParseConfig(args []string) (cfg *Config, err error) {
 		Method:         opts.Method,
 		Head:           opts.Head,
 		Insecure:       opts.Insecure,
+		CACert:         opts.CACert,
 		Data:           opts.Data,
 		OutputJSON:     opts.OutputJSON,
 		OutputPath:     opts.OutputPath,
@@ -322,6 +327,14 @@ func ParseConfig(args []string) (cfg *Config, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid OHTTP keys URL %s: %w", opts.OHTTPKeysURL, err)
 		}
+	}
+
+	// Handle CA certificate file if specified
+	if opts.CACert != "" {
+		if _, err := os.Stat(opts.CACert); err != nil {
+			return nil, fmt.Errorf("CA certificate file not found %s: %w", opts.CACert, err)
+		}
+		cfg.CACert = opts.CACert
 	}
 
 	return cfg, nil

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -41,6 +41,9 @@ type Options struct {
 	// Insecure disables TLS verification of the connection.
 	Insecure bool `short:"k" long:"insecure" description:"Disables TLS verification of the connection." optional:"yes" optional-value:"true"`
 
+	// Provide your own CA certificates
+	CACert string `long:"cacert" description:"Path to custom CA certificate file." value-name:"<file>"`
+
 	// TLSv13 forces to use TLS v1.3.
 	TLSv13 bool `long:"tlsv1.3" description:"Forces gocurl to use TLS v1.3 or newer." optional:"yes" optional-value:"true"`
 


### PR DESCRIPTION
This adds functionality to supply your own CA certificate as in curl. E.g. for testing internal services that are signed with custom CAs.

Thanks for your work and let me know if anything is missing.