### PR TITLE
Preserve original Content-Type in OHTTP requests

### DIFF
--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -31,8 +31,8 @@ func NewRequest(cfg *config.Config) (req *http.Request, err error) {
 		return nil, err
 	}
 
-	addBodyHeaders(req, cfg)
 	addHeaders(req, cfg)
+	addBodyHeaders(req, cfg)
 
 	// Only set default User-Agent if it was not set by the user.
 	if req.Header.Get("User-Agent") == "" {
@@ -60,8 +60,8 @@ func createBody(cfg *config.Config) (body io.Reader, err error) {
 // command-line arguments. For instance, -d/--data requires adding the
 // Content-Type: application/x-www-form-urlencoded header.
 func addBodyHeaders(req *http.Request, cfg *config.Config) {
-	if cfg.Data != "" && !websocket.IsWebSocket(cfg.RequestURL) {
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	if cfg.Data != "" && !websocket.IsWebSocket(cfg.RequestURL) && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
 }
 

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/ameshkov/gocurl/internal/config"
+)
+
+func TestNewRequestPrefersExplicitContentType(t *testing.T) {
+	requestURL, err := url.Parse("https://example.org/")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	cfg := &config.Config{
+		RequestURL: requestURL,
+		Data:       `{"hello":"world"}`,
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+
+	req, err := NewRequest(cfg)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	values := req.Header.Values("Content-Type")
+	if len(values) != 1 || values[0] != "application/json" {
+		t.Fatalf("Content-Type values = %#v, want [application/json]", values)
+	}
+}
+
+func TestNewRequestAddsDefaultFormContentTypeForData(t *testing.T) {
+	requestURL, err := url.Parse("https://example.org/")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	cfg := &config.Config{
+		RequestURL: requestURL,
+		Data:       "a=1",
+		Headers:    make(http.Header),
+	}
+
+	req, err := NewRequest(cfg)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	values := req.Header.Values("Content-Type")
+	if len(values) != 1 || values[0] != "application/x-www-form-urlencoded" {
+		t.Fatalf("Content-Type values = %#v, want [application/x-www-form-urlencoded]", values)
+	}
+}


### PR DESCRIPTION
Current behaviour of gocurl explicitly sets `"Content-Type", "application/x-www-form-urlencoded"` if request data is not empty

```
func addBodyHeaders(req *http.Request, cfg *config.Config) {
	if cfg.Data != "" && !websocket.IsWebSocket(cfg.RequestURL) {
		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
```

If user's request contains its own "Content-Type" header - both headers are clued to one
```
...
"Content-Type": "application/x-www-form-urlencoded  application/json",
```

This is wrong behaviour - we need to overwrite user's request content-type

This PR fix this behaviour